### PR TITLE
[Enum] Adding basic support for enum type

### DIFF
--- a/frontend/ast/AST.cpp
+++ b/frontend/ast/AST.cpp
@@ -284,6 +284,10 @@ Value *StructDeclaration::IRCodegen(IRFactory *IRF) {
   return nullptr;
 }
 
+Value *EnumDeclaration::IRCodegen(IRFactory *IRF) {
+  return nullptr;
+}
+
 Value *CallExpression::IRCodegen(IRFactory *IRF) {
   std::vector<Value *> Args;
 

--- a/frontend/ast/AST.hpp
+++ b/frontend/ast/AST.hpp
@@ -154,6 +154,39 @@ private:
   std::vector<std::unique_ptr<MemberDeclaration>> Members;
 };
 
+class EnumDeclaration : public Statement {
+public:
+  using EnumList = std::vector<std::pair<std::string, int>>;
+
+  EnumDeclaration(Type &BaseType, EnumList Enumerators)
+      : BaseType(BaseType), Enumerators(std::move(Enumerators)) {}
+
+  EnumDeclaration(EnumList Enumerators)
+      : Enumerators(std::move(Enumerators)) {}
+
+  void ASTDump(unsigned tab = 0) override {
+    std::string Str = "EnumDeclaration '";
+    Str += BaseType.ToString() + "'";
+    PrintLn(Str.c_str(), tab);
+    Str.clear();
+    Str = "Enumerators ";
+    unsigned LoopCounter = 0;
+    for (auto &[Enum, Val] : Enumerators) {
+      Str += "'" + Enum + "'";
+      Str += " = " + std::to_string(Val);
+      if (++LoopCounter < Enumerators.size())
+        Str += ", ";
+    }
+    PrintLn(Str.c_str(), tab + 2);
+  }
+
+  Value *IRCodegen(IRFactory *IRF) override;
+
+private:
+  Type BaseType = Type(Type::Int);
+  EnumList Enumerators;
+};
+
 class CompoundStatement : public Statement {
   using DeclVec = std::vector<std::unique_ptr<VariableDeclaration>>;
   using StmtVec = std::vector<std::unique_ptr<Statement>>;
@@ -226,7 +259,8 @@ public:
     PrintLn("IfStatement", tab);
     Condition->ASTDump(tab + 2);
     IfBody->ASTDump(tab + 2);
-    ElseBody->ASTDump(tab + 2);
+    if (ElseBody)
+      ElseBody->ASTDump(tab + 2);
   }
 
   Value *IRCodegen(IRFactory *IRF) override;

--- a/frontend/ast/Type.hpp
+++ b/frontend/ast/Type.hpp
@@ -207,7 +207,7 @@ public:
   bool IsFloat() { return Kind == Float; }
   bool IsEmpty() { return Kind == Empty; }
 
-  unsigned GetIntVal() {
+  int GetIntVal() {
     assert(IsInt() && "Must be an integer type.");
     return IntVal;
   }

--- a/frontend/lexer/Lexer.cpp
+++ b/frontend/lexer/Lexer.cpp
@@ -8,7 +8,8 @@ std::unordered_map<std::string, Token::TokenKind> Lexer::Keywords =
         {"void", Token::Void},     {"char", Token::Char},
         {"if", Token::If},         {"else", Token::Else},
         {"for", Token::For},       {"while", Token::While},
-        {"return", Token::Return}, {"struct", Token::Struct}};
+        {"return", Token::Return}, {"struct", Token::Struct},
+        {"enum", Token::Enum}};
 
 Lexer::Lexer(std::vector<std::string> &s) {
   Source = std::move(s);

--- a/frontend/lexer/Token.hpp
+++ b/frontend/lexer/Token.hpp
@@ -59,6 +59,7 @@ public:
     Double,
     Void,
     Struct,
+    Enum,
   };
 
   Token() : Kind(Invalid) {}
@@ -160,7 +161,8 @@ public:
       return "void";
     case Struct:
       return "struct";
-
+    case Enum:
+      return "struct";
     default:
       assert(false && "Unhandled token type.");
       break;

--- a/frontend/parser/Parser.hpp
+++ b/frontend/parser/Parser.hpp
@@ -42,6 +42,7 @@ public:
   std::unique_ptr<VariableDeclaration> ParseVariableDeclaration();
   std::unique_ptr<MemberDeclaration> ParseMemberDeclaration();
   std::unique_ptr<StructDeclaration> ParseStructDeclaration();
+  std::unique_ptr<EnumDeclaration> ParseEnumDeclaration();
   Node ParseReturnTypeSpecifier();
   std::vector<std::unique_ptr<FunctionParameterDeclaration>>
   ParseParameterList();

--- a/tests/frontend/enum.c
+++ b/tests/frontend/enum.c
@@ -1,0 +1,23 @@
+// RUN: AArch64
+// FUNC-DECL: int test(int)
+// TEST-CASE: test(0) -> 0
+// TEST-CASE: test(1) -> 1
+// TEST-CASE: test(2) -> 2
+// TEST-CASE: test(3) -> 3
+// TEST-CASE: test(4) -> 10
+
+enum { A, B, C, D };
+
+int test(int a) {
+  int res;
+  res = 10;
+  if (A == a)
+    res = a;
+  if (B == a)
+    res = a;
+  if (C == a)
+    res = a;
+  if (D == a)
+    res = a;
+  return res;
+}


### PR DESCRIPTION
For now it is only allowed as top level declaration with no assignments and variable declarations.
Ex: "enum {A, B, C};"