### PR TITLE
[ternary] Adding partial support for ternary operation

### DIFF
--- a/frontend/ast/AST.hpp
+++ b/frontend/ast/AST.hpp
@@ -647,6 +647,44 @@ private:
   std::unique_ptr<Expression> Right;
 };
 
+class TernaryExpression : public Expression {
+  using ExprPtr = std::unique_ptr<Expression>;
+
+public:
+  ExprPtr &GetCondition() { return Condition; }
+  void SetCondition(ExprPtr &e) { Condition = std::move(e); }
+
+  ExprPtr &GetExprIfTrue() { return ExprIfTrue; }
+  void SetExprIfTrue(ExprPtr &e) { ExprIfTrue = std::move(e); }
+
+  ExprPtr &GetExprIfFalse() { return ExprIfFalse; }
+  void SetExprIfFalse(ExprPtr &e) { ExprIfFalse = std::move(e); }
+
+  TernaryExpression() = default;
+
+  TernaryExpression(ExprPtr &Cond, ExprPtr &True, ExprPtr &False)
+  : Condition(std::move(Cond)), ExprIfTrue(std::move(True)),
+        ExprIfFalse(std::move(False)) {
+    ResultType = ExprIfTrue->GetResultType();
+  }
+
+  void ASTDump(unsigned tab = 0) override {
+    Print("TernaryExpression ", tab);
+    auto Str = "'" + ResultType.ToString() + "' ";
+    PrintLn(Str.c_str());
+    Condition->ASTDump(tab + 2);
+    ExprIfTrue->ASTDump(tab + 2);
+    ExprIfFalse->ASTDump(tab + 2);
+  }
+
+  Value *IRCodegen(IRFactory *IRF) override;
+
+private:
+  ExprPtr Condition;
+  ExprPtr ExprIfTrue;
+  ExprPtr ExprIfFalse;
+};
+
 class StructMemberReference : public Expression {
   using ExprPtr = std::unique_ptr<Expression>;
 

--- a/frontend/lexer/Lexer.cpp
+++ b/frontend/lexer/Lexer.cpp
@@ -221,6 +221,9 @@ std::optional<Token> Lexer::LexSymbol() {
     } else
       TokenKind = Token::Bang;
     break;
+  case '?':
+    TokenKind = Token::QuestionMark;
+    break;
   case '&':
     if (GetNextNthCharOnSameLine(1) == '&') {
       TokenKind = Token::DoubleAnd;

--- a/frontend/lexer/Token.hpp
+++ b/frontend/lexer/Token.hpp
@@ -30,6 +30,7 @@ public:
     GreaterThan,
     Bang,
     And,
+    QuestionMark,
 
     // Multichar operators
     PlusPlus,
@@ -136,6 +137,8 @@ public:
       return ">";
     case Bang:
       return "!";
+    case QuestionMark:
+      return "?";
     case PlusPlus:
       return "++";
     case MinusMinus:

--- a/frontend/parser/Parser.cpp
+++ b/frontend/parser/Parser.cpp
@@ -1108,9 +1108,26 @@ Parser::ParseBinaryExpressionRHS(int Precedence,
       }
     }
 
+    // TODO: This will only work here if the ternary condition was in
+    //  parenthesis, which for the time being is sufficient. Make it work as it
+    //  should.
+    if (lexer.Is(Token::QuestionMark))
+      RightExpression = ParseTernaryExpression(std::move(RightExpression));
+
     LeftExpression = std::make_unique<BinaryExpression>(
         std::move(LeftExpression), BinaryOperator, std::move(RightExpression));
   }
+}
+
+// <TernaryExpression> ::= <Expression> '?' <Expression> ':' <Expression>
+std::unique_ptr<Expression>
+Parser::ParseTernaryExpression(std::unique_ptr<Expression> Condition) {
+  Expect(Token::QuestionMark);
+  auto TrueExpr = ParseExpression();
+  Expect(Token::Colon);
+  auto FalseExpr = ParseExpression();
+
+  return std::make_unique<TernaryExpression>(Condition, TrueExpr, FalseExpr);
 }
 
 // <PrimaryExpression> ::= <IdentifierExpression>

--- a/frontend/parser/Parser.hpp
+++ b/frontend/parser/Parser.hpp
@@ -65,6 +65,8 @@ public:
   std::unique_ptr<Expression> ParseUnaryExpression();
   std::unique_ptr<Expression> ParseBinaryExpression();
   std::unique_ptr<Expression>
+  ParseTernaryExpression(std::unique_ptr<Expression> Condition);
+  std::unique_ptr<Expression>
   ParseBinaryExpressionRHS(int Precedence, std::unique_ptr<Expression> LHS);
   std::unique_ptr<Expression> ParseCallExpression(Token ID);
   std::unique_ptr<Expression> ParseArrayExpression(std::unique_ptr<Expression> Base);

--- a/tests/frontend/ternary-operator.c
+++ b/tests/frontend/ternary-operator.c
@@ -1,0 +1,23 @@
+// RUN: AArch64
+
+// FUNC-DECL: int test(int)
+// TEST-CASE: test(0) -> 0
+// TEST-CASE: test(10) -> 10
+// TEST-CASE: test(15) -> 10
+// TEST-CASE: test(20) -> 15
+
+// FUNC-DECL: int test_2(int)
+// TEST-CASE: test_2(0) -> 22
+// TEST-CASE: test_2(1) -> 11
+
+int test(int a) {
+  int res;
+  res = (a > 10) ? a - 5 : a;
+  return res;
+}
+
+int test_2(int a) {
+  int res;
+  res = (a) ? 11 : 22;
+  return res;
+}


### PR DESCRIPTION
Partial since only works if the condition is in parenthesis, also its precedence is not as it should be.