### PR TITLE
[AArch64] Adding support for truncating 64 bit regs to 32 bit regs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(miniCC
     backend/StackFrame.cpp
     backend/TargetInstructionLegalizer.cpp
     backend/TargetMachine.cpp
+    backend/TargetArchs/AArch64/AArch64MOVFixPass.cpp
     backend/TargetArchs/AArch64/AArch64RegisterInfo.cpp
     backend/TargetArchs/AArch64/AArch64InstructionDefinitions.cpp
     backend/TargetArchs/AArch64/AArch64InstructionLegalizer.cpp

--- a/backend/TargetArchs/AArch64/AArch64MOVFixPass.cpp
+++ b/backend/TargetArchs/AArch64/AArch64MOVFixPass.cpp
@@ -1,0 +1,18 @@
+#include "AArch64MOVFixPass.hpp"
+#include "../../MachineInstruction.hpp"
+#include "../../MachineBasicBlock.hpp"
+#include "../../MachineFunction.hpp"
+#include "AArch64InstructionDefinitions.hpp"
+
+void AArch64MOVFixPass::Run() {
+  for (auto &MFunc : MIRM->GetFunctions())
+    for (auto &MBB : MFunc.GetBasicBlocks())
+      for (auto &Instr : MBB.GetInstructions())
+        if (Instr.GetOpcode() == AArch64::MOV_rr &&
+            Instr.GetOperand(0)->GetSize() == 32 &&
+            Instr.GetOperand(1)->GetSize() == 64) {
+          auto SrcXReg = Instr.GetOperand(1)->GetReg();
+          auto WReg = TM->GetRegInfo()->GetRegisterByID(SrcXReg)->GetSubRegs()[0];
+          Instr.GetOperand(1)->SetReg(WReg);
+        }
+}

--- a/backend/TargetArchs/AArch64/AArch64MOVFixPass.hpp
+++ b/backend/TargetArchs/AArch64/AArch64MOVFixPass.hpp
@@ -1,0 +1,19 @@
+#ifndef AARCH64_MOV_FIX_PASS_HPP
+#define AARCH64_MOV_FIX_PASS_HPP
+
+#include "../../MachineIRModule.hpp"
+#include "../../TargetMachine.hpp"
+
+class AArch64MOVFixPass {
+public:
+  AArch64MOVFixPass(MachineIRModule *Module, TargetMachine *TM)
+      : MIRM(Module), TM(TM) {}
+
+  void Run();
+
+private:
+  MachineIRModule *MIRM;
+  TargetMachine *TM;
+};
+
+#endif

--- a/backend/TargetArchs/AArch64/AArch64TargetMachine.cpp
+++ b/backend/TargetArchs/AArch64/AArch64TargetMachine.cpp
@@ -187,6 +187,18 @@ bool AArch64TargetMachine::SelectTRUNC(MachineInstruction *MI) {
     return true;
   }
 
+  // in cases like
+  //      TRUNC  %dst(s32), %src(s64)
+  // for arm only a "mov" instruction is needed, but for $src the W subregister
+  // of the X register should be used, this will be enforced in a later pass
+  if (MI->GetOperand(0)->GetType().GetBitWidth() == 32 &&
+      MI->GetOperand(1)->GetType().GetBitWidth() == 64) {
+    if (!MI->GetOperand(1)->IsImmediate()) {
+      MI->SetOpcode(MOV_rr);
+      return true;
+    }
+  }
+
   assert(!"Unimplemented!");
   return false;
 }

--- a/frontend/ast/AST.cpp
+++ b/frontend/ast/AST.cpp
@@ -614,6 +614,18 @@ Value *CallExpression::IRCodegen(IRFactory *IRF) {
   case Type::UnsignedInt:
     IRRetType = IRType(IRType::UINT);
     break;
+  case Type::Long:
+    IRRetType = IRType(IRType::SINT, 64);
+    break;
+  case Type::UnsignedLong:
+    IRRetType = IRType(IRType::UINT, 64);
+    break;
+  case Type::LongLong:
+    IRRetType = IRType(IRType::SINT, 64);
+    break;
+  case Type::UnsignedLongLong:
+    IRRetType = IRType(IRType::UINT, 64);
+    break;
   case Type::Double:
     IRRetType = IRType(IRType::FP, 64);
     break;
@@ -649,13 +661,15 @@ Value *CallExpression::IRCodegen(IRFactory *IRF) {
 
     IsRetChanged = true;
     Args.push_back(StructTemp);
-    //IRRetType.IncrementPointerLevel();
     IRRetType = IRType::NONE;
     break;
   }
   default:
+    assert(!"Unreachable");
     break;
   }
+
+  assert(!IRRetType.IsInvalid() && "Must be a valid type");
 
   // in case if the ret type was a struct, so StructTemp not nullptr
   if (StructTemp) {

--- a/frontend/frontend_test.cpp
+++ b/frontend/frontend_test.cpp
@@ -6,6 +6,7 @@
 #include "../backend/RegisterAllocator.hpp"
 #include "../backend/TargetArchs/AArch64/AArch64TargetMachine.hpp"
 #include "../backend/TargetArchs/RISCV/RISCVTargetMachine.hpp"
+#include "../backend/TargetArchs/AArch64/AArch64MOVFixPass.hpp"
 #include "../middle_end/IR/IRFactory.hpp"
 #include "lexer/Lexer.hpp"
 #include "parser/Parser.hpp"
@@ -120,9 +121,6 @@ int main(int argc, char *argv[]) {
   if (DumpIR)
     IRModule.Print();
 
-
-
-
   MachineIRModule LLIRModule;
   IRtoLLIR I2LLIR(IRModule, &LLIRModule, TM.get());
   I2LLIR.GenerateLLIRFromIR();
@@ -164,6 +162,9 @@ int main(int argc, char *argv[]) {
   }
   PrologueEpilogInsertion PEI(&LLIRModule, TM.get());
   PEI.Run();
+
+  if (TargetArch == "aarch64")
+    AArch64MOVFixPass(&LLIRModule, TM.get()).Run();
 
   if (PrintBeforePasses) {
     std::cout << "<<<<< Before Emitting Assembly >>>>>" << std::endl

--- a/middle_end/IR/Type.hpp
+++ b/middle_end/IR/Type.hpp
@@ -46,6 +46,7 @@ public:
     return BitWidth == RHS.BitWidth && Kind == RHS.Kind;
   }
 
+  bool IsInvalid() const { return Kind == INVALID; }
   bool IsFP() const { return Kind == FP; }
   bool IsINT() const { return Kind == SINT || Kind == UINT; }
   bool IsPTR() const { return PointerLevel > 0; }

--- a/tests/frontend/aarch64-trunc-64-to-32-bit.c
+++ b/tests/frontend/aarch64-trunc-64-to-32-bit.c
@@ -1,0 +1,9 @@
+// RUN: AArch64
+// FUNC-DECL: int test()
+// TEST-CASE: test() -> 111
+
+
+int test() {
+  long long a = 111;
+  return a;
+}


### PR DESCRIPTION
This is achieved by selecting MOV for it and adding an extra pass which will change MOV's source operand to its W subreg if it was X