### PR TITLE
[TestRun] Extending the test system. Adding the following features

### DIFF
--- a/tests/TestRun.py
+++ b/tests/TestRun.py
@@ -3,48 +3,147 @@ import re
 import subprocess
 from os import path
 import sys
+from dataclasses import dataclass
+from dataclasses import field
 
 save_temps = False
 
+@dataclass
+class Context:
+    arch: str = ""
+    function_declarations: list = field(default_factory=list)
+    test_cases: list = field(default_factory=list)
+    check_list: list = field(default_factory=list)
+    check_not_list: list = field(default_factory=list)
+    run_test: bool = False
+    run_fail_test: bool = False
+    compile_test: bool = False
+    negative_test: bool = False
+    extra_compile_flags: str = ""
+
+def clean_up():
+  if path.exists("test_main.c"):
+    os.remove("test_main.c")
+  if path.exists("test.s"):
+    os.remove("test.s")
+  if path.exists("test"):
+    os.remove("test")
+
 def check_file(file_name):
-    arch = ""
-    function_declarations = []
-    test_cases = []
-    negative_test = False
-    extra_compile_flags = ""
+    context = Context()
 
     with open(file_name) as file:
         for line in file:
             m = re.search(r'(?:/{2}|#) *RUN: (.*)', line)
             if m:
-                arch = m.group(1).lower()
+                context.arch = m.group(1).lower()
+                context.run_test = True
+
+            m = re.search(r'(?:/{2}|#) *RUN-FAIL: (.*)', line)
+            if m:
+                context.arch = m.group(1).lower()
+                context.run_fail_test = True
+
+            m = re.search(r'(?:/{2}|#) *COMPILE-TEST', line)
+            if m:
+                context.compile_test = True
 
             m = re.search(r'(?:/{2}|#) *FUNC-DECL: (.*)', line)
             if m:
-                function_declarations.append(m.group(1))
+                context.function_declarations.append(m.group(1))
+
+            m = re.search(r'(?:/{2}|#) *CHECK:\s*(.*)', line)
+            if m:
+                context.check_list.append(m.group(1))
+
+            m = re.search(r'(?:/{2}|#) *CHECK-NOT:\s*(.*)', line)
+            if m:
+                context.check_not_list.append(m.group(1))
 
             m = re.search(r'(?:/{2}|#) *TEST-CASE: (.*) -> (.*)', line)
             if m:
-                test_cases.append((m.group(1), m.group(2)))
+                context.test_cases.append((m.group(1), m.group(2)))
 
             m = re.search(r'(?:/{2}|#) *COMPILE-FAIL', line)
             if m:
-                negative_test = True
+                context.negative_test = True
 
             m = re.search(r'(?:/{2}|#) *EXTRA-FLAGS: (.*)', line)
             if m:
-                extra_compile_flags = m.group(1)
+                context.extra_compile_flags = m.group(1)
 
-    return arch, function_declarations, test_cases, negative_test, extra_compile_flags
+    return context
 
 
-def execute_tests(file_name, arch, function_declarations, test_cases, extra_compile_flags):
-    run_command = "qemu-" + arch
-    if arch == "":
+def execute_tests(file_name, context):
+    run_command = "qemu-" + context.arch
+    if (context.run_test or context.run_fail_test) and (context.arch == "" or len(context.function_declarations) == 0 or
+                                                        len(context.test_cases) == 0):
+      print("run test requires arch name, function declarations and test cases")
+      return False
+
+    if context.compile_test and len(context.check_list) == 0 and len(context.check_not_list) == 0:
+      print("no CHECK were given")
+      return False
+
+    # create the full command to call the compiler
+    command = ["../build/miniCC", file_name]
+    if context.extra_compile_flags != "":
+      command.append(context.extra_compile_flags)
+
+    # call the compiler
+    result = subprocess.run(command, capture_output=True, timeout=10)
+
+    # if the compilation failed
+    if result.returncode != 0:
+      # if it was a negative test and the fail did not caused by an assertion -> test passed
+      if context.negative_test and not re.search(r'(.*): Assertion(.*)', result.stderr.decode()):
+        return True
+      return False
+
+    # if its a compile test then check the output
+    if context.compile_test:
+      had_checks = len(context.check_list) > 0
+      had_check_nots = len(context.check_not_list) > 0
+
+      for line in result.stdout.decode().splitlines():
+        # if CHECKs were given, then check the output for them
+        if had_checks:
+          if line.find(context.check_list[0]) != -1:
+            context.check_list.pop(0)
+
+            # found all check -> success
+            if len(context.check_list) == 0:
+              return True
+
+        # if there are CHECK-NOTs
+        if had_check_nots:
+          # then check each CHECK-NOT
+          for check_not in context.check_not_list:
+            # if found one in the output -> fail
+            if line.find(check_not) != -1:
+              print("Output contains '", check_not, "', but it should not")
+              return False
+
+      # reached this point and had CHECKs -> did not found all check
+      # print the next check which was not found
+      if had_checks:
+        print("Have not found in the output: ", context.check_list[0])
         return False
+      # reached this point with CHECK-NOTs -> success
+      if had_check_nots:
+        return True
 
+    # RUN test case
+
+    # create the assembly file
+    text_file = open("test.s", "w")
+    text_file.write(result.stdout.decode())
+    text_file.close()
+
+    # create the main C file which used for the testing
     test_main_c_template = "#include <stdio.h>\n\n"
-    for func_decl in function_declarations:
+    for func_decl in context.function_declarations:
         test_main_c_template += func_decl + ";\n\n"
 
     test_main_c_template += "int main() {"
@@ -56,24 +155,12 @@ def execute_tests(file_name, arch, function_declarations, test_cases, extra_comp
     test_main_c_template += "  return 0;"
     test_main_c_template += "}"
 
-    command = ["../build/miniCC", file_name]
-    if extra_compile_flags != "":
-      command.append(extra_compile_flags)
-
-    # TODO: if its an assertion then COMPILE-FAIL should fail since error is expected
-    # not an assertion
-    ret_code = subprocess.run(command,
-                              stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, timeout=10).returncode
-    if ret_code != 0:
-        return False
-
-    test_asm = subprocess.check_output(command).decode("utf-8")
-    text_file = open("test.s", "w")
-    text_file.write(test_asm)
-    text_file.close()
-
-    for case, expected_result in test_cases:
+    # iterate over all the test cases
+    for case, expected_result in context.test_cases:
         current_test_main = test_main_c_template
+        # substitute in the test case and the expected value in the template C code (look above for the C code)
+        # example: // TEST-CASE: test(1) -> 0
+        #   case: test(1), expected_result: 0
         current_test_main = current_test_main.replace("$", case)
         current_test_main = current_test_main.replace("@", expected_result)
 
@@ -81,42 +168,27 @@ def execute_tests(file_name, arch, function_declarations, test_cases, extra_comp
         text_file.write(current_test_main)
         text_file.close()
 
-        compile_ret = subprocess.run([arch + "-linux-gnu-gcc", "test_main.c", "test.s", "-o", "test", "-static", "-lm"]).returncode
+        # compile the C file with the generated assembly
+        compile_ret = subprocess.run([context.arch + "-linux-gnu-gcc", "test_main.c", "test.s", "-o", "test", "-static", "-lm"]).returncode
         if compile_ret != 0:
             if not save_temps:
-              if path.exists("test_main.c"):
-                  os.remove("test_main.c")
-              if path.exists("test.s"):
-                  os.remove("test.s")
-              if path.exists("test"):
-                  os.remove("test")
+              clean_up()
             return False
 
-        ret_code = subprocess.run([run_command, "test"]).returncode
+        # run the generated object file with qemu
+        ret_code = subprocess.run([run_command, "test"], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT).returncode
 
-        if ret_code != 0:
+        if ret_code != 0 and not context.run_fail_test:
             if not save_temps:
-              os.remove("test_main.c")
-              os.remove("test.s")
-              os.remove("test")
+              clean_up()
             return False
 
     if not save_temps:
-      if path.exists("test_main.c"):
-          os.remove("test_main.c")
-      if path.exists("test.s"):
-          os.remove("test.s")
-      if path.exists("test"):
-          os.remove("test")
+      clean_up()
     return True
 
 # clean up files remaining from previous runs
-if path.exists("test_main.c"):
-  os.remove("test_main.c")
-if path.exists("test.s"):
-  os.remove("test.s")
-if path.exists("test"):
-  os.remove("test")
+clean_up()
 
 test_set = []
 failed_tests = []
@@ -146,14 +218,13 @@ test_set.sort() # sort them alphabetically
 
 # run the tests
 for filepath in test_set:
-  arch, function_declarations, test_cases, negative_test, flags = check_file(filepath)
-  if arch == "":
-      continue
+  context = check_file(filepath)
 
-  success = execute_tests(filepath, arch, function_declarations, test_cases, flags)
+  # if no test types were specified, then skip it
+  if not context.run_fail_test and not context.run_test and not context.compile_test and not context.negative_test:
+    continue
 
-  if (negative_test and not success):
-    success = True
+  success = execute_tests(filepath, context)
 
   tests_count += 1
   if success:

--- a/tests/frontend/assertion.c
+++ b/tests/frontend/assertion.c
@@ -1,10 +1,8 @@
-// RUN: AArch64
+// RUN-FAIL: AArch64
 
 // FUNC-DECL: int test(int)
-// TEST-CASE: test(1) -> 1
+// TEST-CASE: test(0) -> 0
 
-// TODO: Add negative test to show that assertion really happens.
-// This is not implemented yet in the test system.
 
 #include <assert.h>
 

--- a/tests/frontend/lexical/do-while-missing-condition.c
+++ b/tests/frontend/lexical/do-while-missing-condition.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   do {

--- a/tests/frontend/lexical/expr-statement-missing-semicolon.c
+++ b/tests/frontend/lexical/expr-statement-missing-semicolon.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   return a

--- a/tests/frontend/lexical/for-missing-2nd-semicolon.c
+++ b/tests/frontend/lexical/for-missing-2nd-semicolon.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   for (int i = 1;)

--- a/tests/frontend/lexical/if-missing-condition.c
+++ b/tests/frontend/lexical/if-missing-condition.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   if()

--- a/tests/frontend/lexical/missing-closing-curly.c
+++ b/tests/frontend/lexical/missing-closing-curly.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   return a;

--- a/tests/frontend/lexical/missing-initialzer-expr-inf-for.c
+++ b/tests/frontend/lexical/missing-initialzer-expr-inf-for.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   for (int i = ;;)

--- a/tests/frontend/lexical/missing-semicolon-struct-declaration.c
+++ b/tests/frontend/lexical/missing-semicolon-struct-declaration.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 struct A {

--- a/tests/frontend/lexical/return-missing-semicolon.c
+++ b/tests/frontend/lexical/return-missing-semicolon.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   return

--- a/tests/frontend/lexical/switch-missing-case-expression.c
+++ b/tests/frontend/lexical/switch-missing-case-expression.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   switch (a) {

--- a/tests/frontend/lexical/switch-missing-condition.c
+++ b/tests/frontend/lexical/switch-missing-condition.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   switch () {

--- a/tests/frontend/lexical/while-missing-condition.c
+++ b/tests/frontend/lexical/while-missing-condition.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   while() {

--- a/tests/frontend/not-supported-features/alignas.c
+++ b/tests/frontend/not-supported-features/alignas.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 struct S {
   float a;

--- a/tests/frontend/not-supported-features/alignof.c
+++ b/tests/frontend/not-supported-features/alignof.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   return _Alignof(a);

--- a/tests/frontend/not-supported-features/atomic.c
+++ b/tests/frontend/not-supported-features/atomic.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   _Atomic int b;

--- a/tests/frontend/not-supported-features/complex.c
+++ b/tests/frontend/not-supported-features/complex.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   _Complex double b;

--- a/tests/frontend/not-supported-features/generic.c
+++ b/tests/frontend/not-supported-features/generic.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 #define typecheck(T) _Generic( (T), char: 1, int: 2, long: 3, float: 4, default: 0)

--- a/tests/frontend/not-supported-features/goto.c
+++ b/tests/frontend/not-supported-features/goto.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test( int a) {
   goto end;

--- a/tests/frontend/not-supported-features/imaginary.c
+++ b/tests/frontend/not-supported-features/imaginary.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   double _Imaginary b;

--- a/tests/frontend/not-supported-features/noreturn.c
+++ b/tests/frontend/not-supported-features/noreturn.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 _Noreturn void test(int a) {
   ;

--- a/tests/frontend/not-supported-features/static-assert.c
+++ b/tests/frontend/not-supported-features/static-assert.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   _Static_assert(3 == 3, "test");

--- a/tests/frontend/not-supported-features/thread-local.c
+++ b/tests/frontend/not-supported-features/thread-local.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   _Thread_local int var = 5;

--- a/tests/frontend/not-yet-supported-features/_Bool.c
+++ b/tests/frontend/not-yet-supported-features/_Bool.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 _Bool test(int a) {
   return a == 1;

--- a/tests/frontend/not-yet-supported-features/enumerator-initialization.c
+++ b/tests/frontend/not-yet-supported-features/enumerator-initialization.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 enum { A = 2, B = 1};
 

--- a/tests/frontend/not-yet-supported-features/extern-variable.c
+++ b/tests/frontend/not-yet-supported-features/extern-variable.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 extern int b;

--- a/tests/frontend/not-yet-supported-features/function-pointer.c
+++ b/tests/frontend/not-yet-supported-features/function-pointer.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 int func(int a) { return a * 2; }

--- a/tests/frontend/not-yet-supported-features/omitted-function-return-type.c
+++ b/tests/frontend/not-yet-supported-features/omitted-function-return-type.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 test(int a) {
   return a;

--- a/tests/frontend/not-yet-supported-features/signed-ret-val.c
+++ b/tests/frontend/not-yet-supported-features/signed-ret-val.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 signed int test(int a) {
   return a;

--- a/tests/frontend/not-yet-supported-features/signed.c
+++ b/tests/frontend/not-yet-supported-features/signed.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(signed int a) {
   return a;

--- a/tests/frontend/not-yet-supported-features/static-function.c
+++ b/tests/frontend/not-yet-supported-features/static-function.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 static int test(int a) {
   return a;

--- a/tests/frontend/not-yet-supported-features/union.c
+++ b/tests/frontend/not-yet-supported-features/union.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 union {

--- a/tests/frontend/not-yet-supported-features/unnamed-struct.c
+++ b/tests/frontend/not-yet-supported-features/unnamed-struct.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 struct {

--- a/tests/frontend/semantics/accessing-unknown-struct-member.c
+++ b/tests/frontend/semantics/accessing-unknown-struct-member.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 struct S { int y; };

--- a/tests/frontend/semantics/assigning-incompatible-type.c
+++ b/tests/frontend/semantics/assigning-incompatible-type.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 struct A { int a; };

--- a/tests/frontend/semantics/assigning-to-const-variable.c
+++ b/tests/frontend/semantics/assigning-to-const-variable.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 const int a;

--- a/tests/frontend/semantics/assigning-to-function.c
+++ b/tests/frontend/semantics/assigning-to-function.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 int func();

--- a/tests/frontend/semantics/dereferencing-non-pointer-type.c
+++ b/tests/frontend/semantics/dereferencing-non-pointer-type.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   return a * *a;

--- a/tests/frontend/semantics/function-redefinition.c
+++ b/tests/frontend/semantics/function-redefinition.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test()
 // COMPILE-FAIL
 
 int test() { return 1; }

--- a/tests/frontend/semantics/implicit-function-declaration.c
+++ b/tests/frontend/semantics/implicit-function-declaration.c
@@ -1,8 +1,6 @@
-// RUN: AArch64
-
-// EXTRA-FLAGS: -Wall
-// FUNC-DECL: int test()
 // COMPILE-FAIL
+// EXTRA-FLAGS: -Wall
+
 
 int test() {
   return func();

--- a/tests/frontend/semantics/invalid-member-access.c
+++ b/tests/frontend/semantics/invalid-member-access.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   return a.x;

--- a/tests/frontend/semantics/invalid-subscript-use.c
+++ b/tests/frontend/semantics/invalid-subscript-use.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int b) {
   return b[1];

--- a/tests/frontend/semantics/invalid-type-for-arrow.c
+++ b/tests/frontend/semantics/invalid-type-for-arrow.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   return a->x;

--- a/tests/frontend/semantics/modulo-with-non-int.c
+++ b/tests/frontend/semantics/modulo-with-non-int.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   a = a % 1.0;

--- a/tests/frontend/semantics/multiple-default-label.c
+++ b/tests/frontend/semantics/multiple-default-label.c
@@ -1,8 +1,6 @@
-// RUN: AArch64
-
-// EXTRA-FLAGS: -Wall
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
+// EXTRA-FLAGS: -Wall
+
 
 int test(int a) {
   switch (a) {

--- a/tests/frontend/semantics/non-integer-case-label.c
+++ b/tests/frontend/semantics/non-integer-case-label.c
@@ -1,7 +1,3 @@
-// RUN: AArch64
-
-// EXTRA-FLAGS: -Wall
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
 
 int test(int a) {

--- a/tests/frontend/semantics/non-lvalue-assignment.c
+++ b/tests/frontend/semantics/non-lvalue-assignment.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int a) {
   0 = a;

--- a/tests/frontend/semantics/parameter-name-omitted.c
+++ b/tests/frontend/semantics/parameter-name-omitted.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int) {
   return 1;

--- a/tests/frontend/semantics/shift-with-non-int-rhs.c
+++ b/tests/frontend/semantics/shift-with-non-int-rhs.c
@@ -1,8 +1,4 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test(int)
 // COMPILE-FAIL
-
 
 int test(int b) {
   return b << 1.0;

--- a/tests/frontend/semantics/struct-initialization.c
+++ b/tests/frontend/semantics/struct-initialization.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test()
 // COMPILE-FAIL
 
 struct Point {

--- a/tests/frontend/semantics/too-few-arguments-for-call.c
+++ b/tests/frontend/semantics/too-few-arguments-for-call.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test()
 // COMPILE-FAIL
 
 int func(int a);

--- a/tests/frontend/semantics/too-many-argument-for-call.c
+++ b/tests/frontend/semantics/too-many-argument-for-call.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test()
 // COMPILE-FAIL
 
 int func(int a);

--- a/tests/frontend/semantics/undefined-symbol.c
+++ b/tests/frontend/semantics/undefined-symbol.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test()
 // COMPILE-FAIL
 
 int test() {

--- a/tests/frontend/semantics/variable-redefinition.c
+++ b/tests/frontend/semantics/variable-redefinition.c
@@ -1,6 +1,3 @@
-// RUN: AArch64
-
-// FUNC-DECL: int test()
 // COMPILE-FAIL
 
 int test() {

--- a/tests/frontend/semantics/void-function-parameter.c
+++ b/tests/frontend/semantics/void-function-parameter.c
@@ -1,7 +1,3 @@
-// RUN: AArch64
-
-// EXTRA-FLAGS: -Wall
-// FUNC-DECL: int test()
 // COMPILE-FAIL
 
 int test(void a) {


### PR DESCRIPTION
  * RUN-FAIL - Run the test with the given architecture, but expect it to fail at runtime
  * COMPILE-TEST - Compile the file only. It is expected that at least one CHECK or CHECK-NOT is present in the file, when using this directive
  * CHECK - For compile test the output of the cmpiler can be matched against strings specified in this directive
  * CHECK-NOT - Similar to CHECK, but it is expected that none of the strings specified in CHECK-NOTs are present in the output